### PR TITLE
Fix PHP Notice with taxonomy term reference

### DIFF
--- a/open_data_schema_map.module
+++ b/open_data_schema_map.module
@@ -1067,7 +1067,7 @@ function open_data_schema_map_endpoint_process_map_recursion(&$result, $map, $ty
         unset($token['odsm_entity_reference']);
         if ($values) {
           $ref_field_info = field_info_field($ref_field);
-          $target_type = $ref_field_info['settings']['target_type'];
+          $target_type = isset($ref_field_info['settings']['target_type']) ? $ref_field_info['settings']['target_type']: FALSE;
           foreach ($values as $num => $item) {
             if ($target_type === 'node') {
               $target_node = entity_load_single('node', $item['target_id']);


### PR DESCRIPTION
I am experiencing PHP notice while using a taxonomy term reference field in a multi value field schema mapping - Notice: Undefined index: target_type in open_data_schema_map_endpoint_process_map_recursion() (line 1070 of /var/www/koeln-dkan/profiles/dkan/modules/contrib/open_data_schema_map/open_data_schema_map.module).